### PR TITLE
Adiciona workflow de deploy para GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,41 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Resumo

- Adiciona `.github/workflows/deploy-pages.yml`: builda o projeto com Webpack (`yarn build`) e publica a pasta `dist/` automaticamente no GitHub Pages a cada push em `master`.

## Próximo passo manual

Após o merge, ative em **Settings → Pages** a opção **Source: GitHub Actions** para o deploy funcionar.


---
_Generated by [Claude Code](https://claude.ai/code/session_015C68FrmFw1i3QkZQ6W4DRN)_